### PR TITLE
Fix response usecase doc

### DIFF
--- a/src/shelf.js
+++ b/src/shelf.js
@@ -1,3 +1,4 @@
+const { checker } = require("@herbsjs/herbs")
 const { entity2diagram, usecase2diagram } = require('@herbsjs/herbs2mermaid')
 const generateHTML = require('./template/default')
 
@@ -24,8 +25,8 @@ const formatUseCaseDoc = (usecase, spec) => {
 	const requestParams = []
 	const responseParams = []
 
-	if (usecase.request) {
-		if (Object.entries(usecase.request).length == 0) responseParams.push({ name: 'Object of', type: usecase.request.name })
+	if (!checker.isEmpty(usecase.request)) {
+		if (Object.entries(usecase.request).length == 0) requestParams.push({ name: 'Object of', type: usecase.request.name })
 		else {
 			Object.entries(usecase.request).map(([key, value]) => {
 				requestParams.push({
@@ -37,10 +38,14 @@ const formatUseCaseDoc = (usecase, spec) => {
 		usecase.request = requestParams
 	}
 
-	if (usecase.response) {
+	if (!checker.isEmpty(usecase.response)) {
 		if (Object.entries(usecase.response).length == 0) responseParams.push({ name: 'Object of', type: usecase.response.name })
 		else {
 			Object.entries(usecase.response).map(([key, value]) => {
+				if (Array.isArray(value)) {
+					responseParams.push({ name: key, type: 'Array of ' + value[0].name })
+					return
+				}
 				responseParams.push({ name: key == '0' ? 'Array of' : key, type: value.name })
 			})
 		}

--- a/test/shelf.test.js
+++ b/test/shelf.test.js
@@ -72,10 +72,12 @@ describe('Generate usecase self-documentation', () => {
 			const uc = usecase('A use case', {
 				request: {
 					param1: String,
-					param2: Number
+					param2: Number,
+					param3: [String]
 				},
 				response: {
-					output1: String
+					output1: String,
+					output2: [String]
 				},
 				'A step': step((ctx) => {
 					ctx.ret.response3 = ctx.req.param2 + 1


### PR DESCRIPTION

![Only response usecase](https://github.com/herbsjs/herbsshelf/assets/8906065/d26cb487-2363-4d14-a53f-3465892a185b)
![Request and response usecase](https://github.com/herbsjs/herbsshelf/assets/8906065/e59b06a9-dd00-4357-afd2-5919ca42329c)

Fixes https://github.com/herbsjs/herbsshelf/issues/57

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Fix push inside if(usecase.request)
2. Adds checker in ifs, because empty object is considered true by javascript
3. Checks if value is array before inserting into responseParams and adds logic to handle array

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
